### PR TITLE
fix: Theme modal mobile layout

### DIFF
--- a/src/components/Themes/ThemeModal.tsx
+++ b/src/components/Themes/ThemeModal.tsx
@@ -69,9 +69,11 @@ const ThemeModal: React.FC<{
           marginTop: { xs: 4, md: 0 },
         }}
       >
-        <IconButton onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
 
         <Grid
           container

--- a/src/components/Themes/ThemeModal.tsx
+++ b/src/components/Themes/ThemeModal.tsx
@@ -69,11 +69,9 @@ const ThemeModal: React.FC<{
           marginTop: { xs: 4, md: 0 },
         }}
       >
-        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-          <IconButton onClick={onClose} sx={{ paddingRight: 0 }}>
-            <CloseIcon />
-          </IconButton>
-        </Box>
+        <IconButton onClick={onClose} sx={{ paddingRight: 0 }}>
+          <CloseIcon />
+        </IconButton>
 
         <Grid
           container

--- a/src/components/Themes/ThemeModal.tsx
+++ b/src/components/Themes/ThemeModal.tsx
@@ -69,7 +69,7 @@ const ThemeModal: React.FC<{
           marginTop: { xs: 4, md: 0 },
         }}
       >
-        <IconButton onClick={onClose} sx={{ paddingRight: 0 }}>
+        <IconButton onClick={onClose}>
           <CloseIcon />
         </IconButton>
 

--- a/src/components/Themes/ThemeModal.tsx
+++ b/src/components/Themes/ThemeModal.tsx
@@ -27,11 +27,7 @@ const ThemeModal: React.FC<{
   onClose: () => void;
   theme: Theme;
   updateFavorites: (theme: Theme, isFavoriting: boolean) => void;
-}> = ({
-  onClose,
-  theme,
-  updateFavorites
-}) => {
+}> = ({ onClose, theme, updateFavorites }) => {
   const { t } = useTranslation("components/themes");
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -64,24 +60,38 @@ const ThemeModal: React.FC<{
           backgroundColor: "background.paper",
           borderRadius: 2,
           boxShadow: 24,
-          p: 4,
+          p: 2,
+          paddingTop: 1,
           maxWidth: "800px",
+          maxHeight: "80vh",
+          overflow: "auto",
           width: "90%",
+          marginTop: { xs: 4, md: 0 },
         }}
       >
-        <IconButton
-          onClick={onClose}
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <IconButton onClick={onClose} sx={{ paddingRight: 0 }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Grid
+          container
+          spacing={2}
           sx={{
-            position: "absolute",
-            top: 16,
-            right: 16,
+            p: 2,
+            flexDirection: { xs: "column-reverse", md: "row" },
           }}
         >
-          <CloseIcon />
-        </IconButton>
-
-        <Grid container spacing={4}>
-          <Grid item xs={12} md={6}>
+          <Grid
+            item
+            xs={12}
+            md={6}
+            sx={{
+              paddingRight: { xs: 0, md: 2 },
+            }}
+            spacing={0}
+          >
             <Typography
               id="theme-modal-title"
               variant="h5"
@@ -179,8 +189,9 @@ const ThemeModal: React.FC<{
               sx={{
                 display: "flex",
                 alignItems: "center",
-                gap: 3,
+                gap: 1,
                 width: { xs: "100%", md: "auto" },
+                py: 2,
               }}
             >
               <Button
@@ -188,33 +199,41 @@ const ThemeModal: React.FC<{
                 variant="contained"
                 color="primary"
                 sx={{
-                  width: { xs: "100%", md: "auto" },
+                  width: "auto",
+                  flexGrow: 1,
                 }}
               >
                 {t("theme_modal.download_theme")}
               </Button>
 
-              <Box sx={{ display: "flex", alignItems: "center", gap: 0 }}>
-                <IconButton 
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  alignSelf: { xs: "flex-start", md: "flex-end" },
+                  gap: 0,
+                }}
+              >
+                <IconButton
                   aria-label="favorite"
                   onClick={handleFavoriteClick}
                   sx={{
                     padding: 1,
-                    '&:hover': {
-                      backgroundColor: 'action.hover'
-                    }
+                    "&:hover": {
+                      backgroundColor: "action.hover",
+                    },
                   }}
                 >
                   <Heart
                     size={20}
-                    color={theme.isFavorite ? 'red' : 'currentColor'}
-                    fill={theme.isFavorite ? 'red' : 'none'}
+                    color={theme.isFavorite ? "red" : "currentColor"}
+                    fill={theme.isFavorite ? "red" : "none"}
                   />
                 </IconButton>
                 <Typography
                   sx={{
-                    color: 'text.primary',
-                    fontSize: '1rem'
+                    color: "text.primary",
+                    fontSize: "1rem",
                   }}
                 >
                   {theme.favoritesCount} {t("theme_modal.likes")}
@@ -223,7 +242,16 @@ const ThemeModal: React.FC<{
             </Box>
           </Grid>
 
-          <Grid item xs={12} md={6} display="flex" justifyContent="center">
+          <Grid
+            item
+            xs={12}
+            md={6}
+            display="flex"
+            justifyContent="center"
+            sx={{
+              paddingRight: { xs: 0, md: 2 },
+            }}
+          >
             <Box
               component="img"
               src={theme.themeImg}


### PR DESCRIPTION
#### Description

The old modal that shows up on clicking "More info" on a theme card does not behave properly on mobile screens. 

Closes #88

#### What change does this PR introduce?

Please select the relevant option(s).

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD (updates related to the CI/CD process)
- [ ] Documentation update (changes to docs/code comments)
- [ ] Chore (miscellaneous tasks that do not fall into the above options)

#### What is the proposed approach?

The solution involves getting a fix on the mobile layout. 

1. Inverting the flow of image and description sections on smaller screens
2. Restricting the maximum height of the modal to a certain responsive value.
3. Making the modal scrollable on smaller screens in order to access clipped content
4. Introduced minor changes to the grid gutters to adjust the alignments of the sections

#### Checklist:

- [X] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)