### PR TITLE
fix: margin top issue for box content below navbar

### DIFF
--- a/src/pages/Plugins.tsx
+++ b/src/pages/Plugins.tsx
@@ -180,7 +180,11 @@ const Plugins: React.FC = () => {
     >
       {/* Main Content Section */}
       <Box sx={{ flex: 1, padding: 4 }}>
-        <Box mb={4}>
+        <Box 
+          sx={{
+            mt: { xs: 5, sm: 5, md: 5, lg: 0, xl: 0 },
+            mb: 4,
+          }}>
           <Typography variant="h4" fontWeight="bold" color="text.primary" mb={3}>
             {t("plugins.header")}
           </Typography>

--- a/src/pages/Themes.tsx
+++ b/src/pages/Themes.tsx
@@ -200,7 +200,11 @@ const Themes: React.FC = () => {
     >
       {/* Main Content Section */}
       <Box sx={{ flex: 1, padding: 4 }}>
-        <Box mb={4}>
+        <Box 
+          sx={{
+            mt: { xs: 5, sm: 5, md: 5, lg: 0, xl: 0 },
+            mb: 4,
+          }}>
           <Typography variant="h4" fontWeight="bold" color="text.primary" mb={3}>
             {t("themes.header")}
           </Typography>


### PR DESCRIPTION
**Title: Fix Margin Top Issue for Box Content Below Navbar**

Description:

This pull request addresses an issue where page titles (e.g., Themes, Plugins) are hidden behind the navigation bar on mobile devices. The fix involves adjusting the margin top (mt) of the content box using Material UI's responsive breakpoints to ensure that page titles are visible below the navigation bar.

Changes:

Modified the Themes.tsx and Plugins.tsx files to apply a margin top of 5 units on mobile and tablet devices (xs, sm, md) and 0 on desktop devices (lg, xl).

Bug Description:

Issue: 
On mobile view, page titles are hidden behind the navigation bar.

Steps to Reproduce:
- Go to the 'themes page' on mobile.
- Notice the themes title is not visible at the top but is hidden behind the navigation bar.
- Expected Behavior: Themes title should be visible below the navigation bar.

What Change Does This PR Introduce?
- Adds a margin top prop for styling to ensure page titles are visible below the navigation bar on mobile devices.

Please select the relevant option(s).

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD (updates related to the CI/CD process)
- [ ] Documentation update (changes to docs/code comments)
- [ ] Chore (miscellaneous tasks that do not fall into the above options)

Checklist:

- [X] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)

Screenshots:

![image](https://github.com/user-attachments/assets/499d55d9-e1f1-41da-91ac-90475b3d711c)
![image](https://github.com/user-attachments/assets/37a295aa-c322-468f-84f7-fbeec5ecebcc)
