### PR TITLE
test(ourteam): add comprehensive unit tests for TeamMemberCard (Vitest + RTL)

### DIFF
--- a/src/components/OurTeam/TeamMemberCard.test.tsx
+++ b/src/components/OurTeam/TeamMemberCard.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TeamMember } from '@/interfaces/TeamMember';
+
+import TeamMemberCard from './TeamMemberCard';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, def?: string) => def ?? _key,
+  }),
+}));
+
+const mockUseIsDesktop = vi.fn(() => true);
+vi.mock('@/hooks/useIsDesktop', () => ({
+  __esModule: true,
+  default: () => mockUseIsDesktop(),
+}));
+
+const mkMember = (overrides: Partial<TeamMember> = {}): TeamMember => ({
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  avatarUrl: 'https://example.com/avatar.png',
+  githubUrl: 'https://github.com/adalovelace',
+  roles: [
+    { name: 'Core Maintainer', project: 'Compute', link: 'https://example.com/compute' } as any,
+    { name: 'Research', project: undefined, link: '' } as any,
+  ],
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockUseIsDesktop.mockReturnValue(true);
+  vi.restoreAllMocks();
+});
+
+describe('TeamMemberCard', () => {
+  it('renders avatar image when avatarUrl is provided', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByAltText(member.name)).toBeInTheDocument();
+  });
+
+  it('hides the image element after an onError event', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    const img = screen.getByAltText(member.name) as HTMLImageElement;
+    fireEvent.error(img);
+    expect(img.style.display).toBe('none');
+  });
+
+  it('renders fallback icon when no avatarUrl is provided', () => {
+    const member = mkMember({ avatarUrl: undefined });
+    const { container } = render(<TeamMemberCard member={member} />);
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders member name', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByText(member.name)).toBeInTheDocument();
+  });
+
+  it('renders GitHub link with correct attributes', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    const link = screen.getByRole('link', { name: /GitHub/i });
+    expect(link).toHaveAttribute('href', member.githubUrl);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders roles with and without project labels', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByText('Compute')).toBeInTheDocument();
+    expect(screen.getByText('Core Maintainer')).toBeInTheDocument();
+    expect(screen.getByText('Research')).toBeInTheDocument();
+  });
+
+  it('opens window when clicking a role that has link', () => {
+    const member = mkMember();
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null as any);
+    render(<TeamMemberCard member={member} />);
+    fireEvent.click(screen.getByText('Core Maintainer'));
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/compute');
+  });
+
+  it('does not open window when clicking a role without link', () => {
+    const member = mkMember();
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null as any);
+    render(<TeamMemberCard member={member} />);
+    fireEvent.click(screen.getByText('Research'));
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders correctly on mobile (useIsDesktop=false)', () => {
+    mockUseIsDesktop.mockReturnValue(false);
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByText(member.name)).toBeInTheDocument();
+  });
+
+  it('supports multiple roles and renders them all', () => {
+    const member = mkMember({
+      roles: [
+        { name: 'Design', project: 'UI', link: '' } as any,
+        { name: 'Docs', project: undefined, link: '' } as any,
+        { name: 'QA', project: 'Release', link: 'https://example.com/release' } as any,
+      ],
+    });
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByText('UI')).toBeInTheDocument();
+    expect(screen.getByText('Design')).toBeInTheDocument();
+    expect(screen.getByText('Docs')).toBeInTheDocument();
+    expect(screen.getByText('Release')).toBeInTheDocument();
+    expect(screen.getByText('QA')).toBeInTheDocument();
+  });
+
+  it('renders the GitHub label via i18n default value', () => {
+    const member = mkMember();
+    render(<TeamMemberCard member={member} />);
+    expect(screen.getByRole('link', { name: /GitHub/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#### Description

Adds a comprehensive **unit test suite** for the `TeamMemberCard` component using **Vitest + React Testing Library**.  
Tests are co-located next to the component and focus on behavior (not styles), including avatar rendering/fallback, GitHub link attributes, role chip labeling, and click behavior for roles with/without links.

Closes #116

---

#### What change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD (updates related to the CI/CD process)
- [x] Chore (miscellaneous tasks that do not fall into the above options)

---

#### What is the proposed approach?

- **Testing strategy:** Vitest + React Testing Library with co-located tests.
- **Mocks:**  
  - `react-i18next` mocked to return default strings for stability.  
  - `useIsDesktop` mocked to validate both desktop and mobile code paths.
- **Behavior covered:**
  - Renders avatar `<img>` when `avatarUrl` is provided; hides `<img>` on `onError` (fallback behavior).
  - Falls back to icon when `avatarUrl` is absent.
  - Displays member name.
  - Renders GitHub link with correct `href`, `target="_blank"`, and `rel="noopener noreferrer"`.
  - Renders role chips:
    - Two-line label when `project` is present.
    - Single-line label when `project` is absent.
  - Clicking a role with `link` calls `window.open(link)`; clicking a role without `link` is a no-op.
  - Supports multiple roles.
- **Scope:** Tests only; no production code changes.

---

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features) 
